### PR TITLE
Implement local RAG agent scaffolding

### DIFF
--- a/agent-rag-local/README.md
+++ b/agent-rag-local/README.md
@@ -1,0 +1,33 @@
+# Agent RAG Local
+
+This project implements a simple Retrieval-Augmented Generation agent that runs entirely locally. It processes PDF and Jupyter notebook course materials for the BUT SD programming modules and allows students to ask questions via a command line interface.
+
+## Setup
+
+```bash
+python install_dependencies.py
+```
+
+## Usage
+
+Build the vector index (only needed the first time or when supports change):
+
+```bash
+python main.py --build-index
+```
+
+Then start asking questions:
+
+```bash
+python main.py
+```
+
+## Project structure
+
+- `preprocess/extract_text.py` – extract text from PDFs and notebooks
+- `vector_store/build_qdrant_index.py` – chunk documents and build the Qdrant vector store
+- `retrieval/search_chunks.py` – retrieve relevant chunks for a question
+- `generation/generate_answer.py` – call the local Ollama model with retrieved context
+- `main.py` – command line interface
+
+All dependencies are listed in `requirements.txt`.

--- a/agent-rag-local/generation/generate_answer.py
+++ b/agent-rag-local/generation/generate_answer.py
@@ -1,0 +1,14 @@
+import subprocess
+
+MODEL_NAME = "llama2"
+
+
+def generate(prompt: str) -> str:
+    proc = subprocess.run(["ollama", "run", MODEL_NAME], input=prompt.encode(), capture_output=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.decode())
+    return proc.stdout.decode()
+
+
+if __name__ == "__main__":
+    print(generate("Bonjour"))

--- a/agent-rag-local/install_dependencies.py
+++ b/agent-rag-local/install_dependencies.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+
+
+def install():
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+
+if __name__ == "__main__":
+    install()

--- a/agent-rag-local/main.py
+++ b/agent-rag-local/main.py
@@ -1,0 +1,48 @@
+import argparse
+
+from preprocess.extract_text import preprocess
+from vector_store.build_qdrant_index import build_index
+from retrieval.search_chunks import search
+from generation.generate_answer import generate
+
+
+def build():
+    preprocess()
+    build_index()
+
+
+def chat():
+    while True:
+        try:
+            question = input("Question > ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not question.strip():
+            continue
+        chunks = search(question)
+        context = "\n\n".join(chunks)
+        prompt = (
+            "Tu es un assistant pour les étudiants de BUT SD.\n"
+            "Voici des extraits de cours pertinents :\n---\n"
+            f"{context}\n---\n"
+            f"Question : {question}\nRéponds clairement et précisément."
+        )
+        try:
+            answer = generate(prompt)
+        except Exception as e:
+            print(f"Erreur génération : {e}")
+            continue
+        print(answer)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-index", action="store_true", help="rebuild vector index")
+    args = parser.parse_args()
+    if args.build_index:
+        build()
+    chat()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-rag-local/preprocess/extract_text.py
+++ b/agent-rag-local/preprocess/extract_text.py
@@ -1,0 +1,40 @@
+import os
+import nbformat
+import fitz  # PyMuPDF
+from pathlib import Path
+
+SUPPORTS_DIR = Path(__file__).resolve().parents[1] / "supports"
+OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def extract_pdf(path: Path) -> str:
+    doc = fitz.open(path)
+    text = "\n".join(page.get_text() for page in doc)
+    doc.close()
+    return text
+
+
+def extract_notebook(path: Path) -> str:
+    nb = nbformat.read(path, as_version=4)
+    texts = [cell.get("source", "") for cell in nb.cells]
+    return "\n".join(texts)
+
+
+def preprocess():
+    for root, _, files in os.walk(SUPPORTS_DIR):
+        for f in files:
+            p = Path(root) / f
+            if p.suffix.lower() == ".pdf":
+                text = extract_pdf(p)
+            elif p.suffix.lower() == ".ipynb":
+                text = extract_notebook(p)
+            else:
+                continue
+            out_path = OUTPUT_DIR / f"{p.stem}.txt"
+            out_path.write_text(text)
+            print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    preprocess()

--- a/agent-rag-local/requirements.txt
+++ b/agent-rag-local/requirements.txt
@@ -1,0 +1,6 @@
+langchain
+sentence-transformers
+qdrant-client
+pymupdf
+nbformat
+ollama

--- a/agent-rag-local/retrieval/search_chunks.py
+++ b/agent-rag-local/retrieval/search_chunks.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+from qdrant_client import QdrantClient
+
+COLLECTION_NAME = "but_sd_supports"
+model = SentenceTransformer("all-MiniLM-L6-v2")
+client = QdrantClient(path=str(Path.home() / ".qdrant"))
+
+
+def search(query: str, k: int = 3) -> List[str]:
+    vector = model.encode([query])[0].tolist()
+    results = client.search(collection_name=COLLECTION_NAME, query_vector=vector, limit=k)
+    return [r.payload.get("text", "") for r in results]
+
+
+if __name__ == "__main__":
+    for c in search("qu'est ce qu'une fonction ?"):
+        print("--", c[:80])

--- a/agent-rag-local/vector_store/build_qdrant_index.py
+++ b/agent-rag-local/vector_store/build_qdrant_index.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from typing import List
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from sentence_transformers import SentenceTransformer
+from qdrant_client import QdrantClient
+from qdrant_client.models import VectorParams, Distance, PointStruct
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "preprocess" / "output"
+COLLECTION_NAME = "but_sd_supports"
+
+
+def load_documents() -> List[str]:
+    return [p.read_text() for p in DATA_DIR.glob("*.txt")]
+
+
+def build_index():
+    docs = load_documents()
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    chunks = [chunk for doc in docs for chunk in splitter.split_text(doc)]
+
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    embeddings = model.encode(chunks, show_progress_bar=True)
+
+    client = QdrantClient(path=str(Path.home() / ".qdrant"))
+    if COLLECTION_NAME in [c.name for c in client.get_collections().collections]:
+        client.delete_collection(COLLECTION_NAME)
+    client.create_collection(COLLECTION_NAME, vectors_config=VectorParams(size=embeddings.shape[1], distance=Distance.COSINE))
+
+    points = [PointStruct(id=i, vector=embeddings[i].tolist(), payload={"text": chunks[i]}) for i in range(len(chunks))]
+    client.upload_collection(collection_name=COLLECTION_NAME, points=points)
+    print(f"Indexed {len(chunks)} chunks")
+
+
+if __name__ == "__main__":
+    build_index()


### PR DESCRIPTION
## Summary
- add project scaffold for a local RAG agent
- include preprocessing of PDFs and notebooks
- build Qdrant index with MiniLM embeddings
- provide retrieval and generation helpers
- simple CLI for chat and index building

## Testing
- `python -m py_compile agent-rag-local/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68552ce298e8832d8e716103906baf33