### PR TITLE
Replace Qdrant with FAISS vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Contexte : Tu es un ingénieur Data/IA chargé de développer un agent conversat
 - Prétraitement des supports (extraction de texte depuis PDF et notebooks)  
 - Découpage en « chunks » avec chevauchement  
 - Vectorisation des chunks via SentenceTransformers  
-- Indexation et stockage local des vecteurs dans Qdrant  
+- Indexation et stockage local des vecteurs dans FAISS
 - Retrieval des chunks pertinents selon la question utilisateur  
 - Génération de la réponse avec le modèle Ollama (exécuté via llama.cpp / ollama)  
 - Interface CLI simple  
 Plan détaillé à implémenter :  
 1. Prétraitement (preprocess/) : extraire le texte des PDF (PyMuPDF ou pdfminer.six) et des notebooks (nbformat), nettoyer et sauvegarder chaque document en .txt  
-2. Chunking & Vectorisation (vector_store/) : charger les .txt, découper en chunks de ~500 tokens avec overlap de 50, encoder chaque chunk avec SentenceTransformer("all-MiniLM-L6-v2"), indexer les vecteurs dans Qdrant via qdrant-client  
+2. Chunking & Vectorisation (vector_store/) : charger les .txt, découper en chunks de ~500 tokens avec overlap de 50, encoder chaque chunk avec SentenceTransformer("all-MiniLM-L6-v2"), indexer les vecteurs dans FAISS
 3. Retrieval & RAG (retrieval/ + generation/) :  
    a. Encoder la question utilisateur avec le même SentenceTransformer  
-   b. Rechercher les K chunks les plus proches (cosine similarity) dans Qdrant  
+   b. Rechercher les K chunks les plus proches (cosine similarity) dans FAISS
    c. Construire un prompt structuré :  
       Tu es un assistant pour les étudiants de BUT SD.  
       Voici des extraits de cours pertinents :  
@@ -25,7 +25,7 @@ Plan détaillé à implémenter :
       Question : <texte de la question>  
       Réponds clairement et précisément.  
    d. Envoyer ce prompt à Ollama via subprocess ou SDK Python pour générer la réponse  
-4. CLI (main.py) : boucle input("Question > ") → pipeline RAG → affichage de la réponse ; option --build-index pour (re)construire la base Qdrant  
+4. CLI (main.py) : boucle input("Question > ") → pipeline RAG → affichage de la réponse ; option --build-index pour (re)construire la base FAISS
 5. Structure du projet :  
 /agent-rag-local/  
 ├── install_dependencies.py  
@@ -33,7 +33,7 @@ Plan détaillé à implémenter :
 ├── preprocess/  
 │   └── extract_text.py  
 ├── vector_store/  
-│   └── build_qdrant_index.py  
+│   └── build_faiss_index.py
 ├── retrieval/  
 │   └── search_chunks.py  
 ├── generation/  
@@ -41,4 +41,4 @@ Plan détaillé à implémenter :
 ├── supports/  (PDF et .ipynb)  
 ├── README.md  
 └── requirements.txt  
-Contraintes techniques : Python 3.10+, LangChain pour orchestrer la RAG, modèle Ollama local, Qdrant en local, SentenceTransformers all-MiniLM-L6-v2, extraction PDF locale, exécution 100% locale.  
+Contraintes techniques : Python 3.10+, LangChain pour orchestrer la RAG, modèle Ollama local, FAISS en local, SentenceTransformers all-MiniLM-L6-v2, extraction PDF locale, exécution 100% locale.

--- a/agent-rag-local/README.md
+++ b/agent-rag-local/README.md
@@ -1,0 +1,33 @@
+# Agent RAG Local
+
+This project implements a simple Retrieval-Augmented Generation agent that runs entirely locally. It processes PDF and Jupyter notebook course materials for the BUT SD programming modules and allows students to ask questions via a command line interface.
+
+## Setup
+
+```bash
+python install_dependencies.py
+```
+
+## Usage
+
+Build the vector index (only needed the first time or when supports change):
+
+```bash
+python main.py --build-index
+```
+
+Then start asking questions:
+
+```bash
+python main.py
+```
+
+## Project structure
+
+- `preprocess/extract_text.py` – `Preprocessor` class for extracting text from supports
+- `vector_store/build_faiss_index.py` – `FaissIndexBuilder` class to build the vector store
+- `retrieval/search_chunks.py` – `Retriever` class to search for relevant chunks
+- `generation/generate_answer.py` – `AnswerGenerator` class wrapping the Ollama model
+- `main.py` – `LocalRAGAgent` command line interface
+
+All dependencies are listed in `requirements.txt`.

--- a/agent-rag-local/generation/generate_answer.py
+++ b/agent-rag-local/generation/generate_answer.py
@@ -1,0 +1,18 @@
+"""Generate answers using a local Ollama model."""
+
+import subprocess
+
+
+class AnswerGenerator:
+    def __init__(self, model_name: str = "llama2") -> None:
+        self.model_name = model_name
+
+    def generate(self, prompt: str) -> str:
+        proc = subprocess.run(["ollama", "run", self.model_name], input=prompt.encode(), capture_output=True)
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.decode())
+        return proc.stdout.decode()
+
+
+if __name__ == "__main__":
+    print(AnswerGenerator().generate("Bonjour"))

--- a/agent-rag-local/install_dependencies.py
+++ b/agent-rag-local/install_dependencies.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+
+
+def install():
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+
+if __name__ == "__main__":
+    install()

--- a/agent-rag-local/main.py
+++ b/agent-rag-local/main.py
@@ -1,0 +1,61 @@
+"""Command line interface for the local RAG agent."""
+
+import argparse
+
+from preprocess.extract_text import Preprocessor
+from vector_store.build_faiss_index import FaissIndexBuilder
+from retrieval.search_chunks import Retriever
+from generation.generate_answer import AnswerGenerator
+
+
+class LocalRAGAgent:
+    def __init__(self) -> None:
+        self.preprocessor = Preprocessor()
+        self.index_builder = FaissIndexBuilder()
+        self.retriever = Retriever()
+        self.generator = AnswerGenerator()
+
+    def build(self) -> None:
+        self.preprocessor.run()
+        self.index_builder.build()
+
+    def answer(self, question: str) -> str:
+        chunks = self.retriever.search(question)
+        context = "\n\n".join(chunks)
+        prompt = (
+            "Tu es un assistant pour les étudiants de BUT SD.\n"
+            "Voici des extraits de cours pertinents :\n---\n"
+            f"{context}\n---\n"
+            f"Question : {question}\nRéponds clairement et précisément."
+        )
+        return self.generator.generate(prompt)
+
+    def chat(self) -> None:
+        while True:
+            try:
+                question = input("Question > ")
+            except (EOFError, KeyboardInterrupt):
+                break
+            if not question.strip():
+                continue
+            try:
+                answer = self.answer(question)
+            except Exception as e:  # pragma: no cover - runtime errors
+                print(f"Erreur génération : {e}")
+                continue
+            print(answer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-index", action="store_true", help="rebuild vector index")
+    args = parser.parse_args()
+
+    agent = LocalRAGAgent()
+    if args.build_index:
+        agent.build()
+    agent.chat()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-rag-local/preprocess/extract_text.py
+++ b/agent-rag-local/preprocess/extract_text.py
@@ -1,0 +1,45 @@
+"""Utilities to extract text from PDF and notebook files."""
+
+import os
+from pathlib import Path
+
+import nbformat
+import fitz  # PyMuPDF
+
+
+class Preprocessor:
+    """Convert course supports into plain text files."""
+
+    def __init__(self, supports_dir: Path | None = None, output_dir: Path | None = None) -> None:
+        self.supports_dir = supports_dir or Path(__file__).resolve().parents[1] / "supports"
+        self.output_dir = output_dir or Path(__file__).resolve().parent / "output"
+        self.output_dir.mkdir(exist_ok=True)
+
+    def _extract_pdf(self, path: Path) -> str:
+        doc = fitz.open(path)
+        text = "\n".join(page.get_text() for page in doc)
+        doc.close()
+        return text
+
+    def _extract_notebook(self, path: Path) -> str:
+        nb = nbformat.read(path, as_version=4)
+        texts = [cell.get("source", "") for cell in nb.cells]
+        return "\n".join(texts)
+
+    def run(self) -> None:
+        for root, _, files in os.walk(self.supports_dir):
+            for f in files:
+                p = Path(root) / f
+                if p.suffix.lower() == ".pdf":
+                    text = self._extract_pdf(p)
+                elif p.suffix.lower() == ".ipynb":
+                    text = self._extract_notebook(p)
+                else:
+                    continue
+                out_path = self.output_dir / f"{p.stem}.txt"
+                out_path.write_text(text)
+                print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    Preprocessor().run()

--- a/agent-rag-local/requirements.txt
+++ b/agent-rag-local/requirements.txt
@@ -1,0 +1,6 @@
+langchain
+sentence-transformers
+faiss-cpu
+pymupdf
+nbformat
+ollama

--- a/agent-rag-local/retrieval/search_chunks.py
+++ b/agent-rag-local/retrieval/search_chunks.py
@@ -1,0 +1,23 @@
+"""Retrieve relevant text chunks from a FAISS index."""
+
+from pathlib import Path
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+from langchain.vectorstores import FAISS
+
+
+class Retriever:
+    def __init__(self, index_dir: Path | None = None) -> None:
+        self.model = SentenceTransformer("all-MiniLM-L6-v2")
+        self.index_dir = index_dir or Path(__file__).resolve().parents[1] / "vector_store" / "faiss_index"
+        self.vector_store = FAISS.load_local(str(self.index_dir), self.model)
+
+    def search(self, query: str, k: int = 3) -> List[str]:
+        docs = self.vector_store.similarity_search(query, k=k)
+        return [d.page_content for d in docs]
+
+
+if __name__ == "__main__":
+    for c in Retriever().search("qu'est ce qu'une fonction ?"):
+        print("--", c[:80])

--- a/agent-rag-local/vector_store/build_faiss_index.py
+++ b/agent-rag-local/vector_store/build_faiss_index.py
@@ -1,0 +1,42 @@
+"""Build a FAISS vector index from plain text documents."""
+
+from pathlib import Path
+from typing import Iterable, List
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from sentence_transformers import SentenceTransformer
+from langchain.vectorstores import FAISS
+
+
+class FaissIndexBuilder:
+    def __init__(
+        self,
+        data_dir: Path | None = None,
+        index_dir: Path | None = None,
+        chunk_size: int = 500,
+        chunk_overlap: int = 50,
+    ) -> None:
+        self.data_dir = data_dir or Path(__file__).resolve().parents[1] / "preprocess" / "output"
+        self.index_dir = index_dir or Path(__file__).resolve().parent / "faiss_index"
+        self.index_dir.mkdir(exist_ok=True)
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    def _load_documents(self) -> List[str]:
+        return [p.read_text() for p in self.data_dir.glob("*.txt")]
+
+    def _chunk_documents(self, docs: Iterable[str]) -> List[str]:
+        splitter = RecursiveCharacterTextSplitter(chunk_size=self.chunk_size, chunk_overlap=self.chunk_overlap)
+        return [chunk for doc in docs for chunk in splitter.split_text(doc)]
+
+    def build(self) -> None:
+        docs = self._load_documents()
+        chunks = self._chunk_documents(docs)
+        vector_store = FAISS.from_texts(chunks, self.model)
+        vector_store.save_local(str(self.index_dir))
+        print(f"Indexed {len(chunks)} chunks to {self.index_dir}")
+
+
+if __name__ == "__main__":
+    FaissIndexBuilder().build()


### PR DESCRIPTION
## Summary
- drop Qdrant index builder and switch to FAISS
- update retriever and CLI to work with FAISS index
- adjust documentation and dependencies for FAISS

## Testing
- `python -m py_compile agent-rag-local/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68552ce298e8832d8e716103906baf33